### PR TITLE
feat(kafka): Add Kafka config and code into /generate API

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -8,7 +8,7 @@
         <sourceTestOutputDir name="target/generated-test-sources/test-annotations" />
         <outputRelativeToContentRoot value="true" />
         <processorPath useClasspath="false">
-          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/unknown/lombok-unknown.jar" />
+          <entry name="$MAVEN_REPOSITORY$/org/projectlombok/lombok/1.18.30/lombok-1.18.30.jar" />
           <entry name="$MAVEN_REPOSITORY$/org/springframework/boot/spring-boot-configuration-processor/unknown/spring-boot-configuration-processor-unknown.jar" />
         </processorPath>
         <module name="generator" />

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -57,7 +57,8 @@
 		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
-			<optional>true</optional>
+			<version>1.18.30</version>
+			<scope>provided</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -74,6 +75,11 @@
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
 			<version>2.1.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka</artifactId>
+		</dependency>
+
 	</dependencies>
 
 	<build>
@@ -86,6 +92,7 @@
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>1.18.30</version>
 						</path>
 						<path>
 							<groupId>org.springframework.boot</groupId>

--- a/backend/src/main/java/com/rapidcrud/generator/kafka/AuditLogEvent.java
+++ b/backend/src/main/java/com/rapidcrud/generator/kafka/AuditLogEvent.java
@@ -1,0 +1,18 @@
+package com.rapidcrud.generator.kafka;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditLogEvent {
+    private String action;
+    private String entity;
+    private String payload;
+    private LocalDateTime timestamp;
+}
+

--- a/backend/src/main/java/com/rapidcrud/generator/kafka/KafkaConsumerService.java
+++ b/backend/src/main/java/com/rapidcrud/generator/kafka/KafkaConsumerService.java
@@ -1,0 +1,13 @@
+package com.rapidcrud.generator.kafka;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+@Service
+public class KafkaConsumerService {
+
+    @KafkaListener(topics = "audit-log-topic", groupId = "audit-consumer-group")
+    public void consume(AuditLogEvent event) {
+        System.out.println("📥 Received Kafka log: " + event);
+    }
+}

--- a/backend/src/main/java/com/rapidcrud/generator/kafka/KafkaProducerService.java
+++ b/backend/src/main/java/com/rapidcrud/generator/kafka/KafkaProducerService.java
@@ -1,0 +1,17 @@
+package com.rapidcrud.generator.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class KafkaProducerService {
+
+    private final KafkaTemplate<String, AuditLogEvent> kafkaTemplate;
+
+    public void sendLog(AuditLogEvent event) {
+        kafkaTemplate.send("audit-log-topic", event);
+        System.out.println("✅ Sent Kafka log: " + event);
+    }
+}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=generator

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+  application:
+    name: generator
+
+  kafka:
+    bootstrap-servers: localhost:9092
+    consumer:
+      group-id: audit-consumer-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
+      properties:
+        spring.json.trusted.packages: "*"
+    producer:
+      key-serializer: org.apache.kafka.common.serialization.StringSerializer
+      value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+    template:
+      default-topic: audit-log-topic
+
+  data:
+    mongodb:
+      host: localhost
+      port: 27017
+      database: rapid_crud_logs

--- a/backend/target/classes/application.properties
+++ b/backend/target/classes/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=generator

--- a/docker-dev-env/docker-compose.yml
+++ b/docker-dev-env/docker-compose.yml
@@ -1,0 +1,49 @@
+version: '3.8'
+
+services:
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:7.5.0
+    container_name: zookeeper
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+
+  kafka:
+    image: confluentinc/cp-kafka:7.5.0
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - "9092:9092"
+      - "29092:29092"
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://localhost:9092,PLAINTEXT_HOST://kafka:29092
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092,PLAINTEXT_HOST://0.0.0.0:29092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+
+  kafka-ui:
+    image: docker.io/redpandadata/console:latest
+    container_name: kafka-ui
+    ports:
+      - "8081:8080"
+    environment:
+      - KAFKA_BROKERS=kafka:29092
+      - CONSOLE_AUTHENTICATION_ENABLED=false
+    depends_on:
+      - kafka
+
+  mongo:
+    image: mongo:6.0
+    container_name: mongo
+    ports:
+      - "27017:27017"
+    volumes:
+      - mongo_data:/data/db
+
+volumes:
+  mongo_data:


### PR DESCRIPTION
## Description
This PR integrates Kafka into the project to support audit logging for /generate API calls.

## Changes

- Added Docker Compose configuration for Kafka, Kafka UI, Zookeeper, and MongoDB
- Added AuditLogEvent entity to represent audit logs
- Implemented Kafka producer and consumer services
- Triggered audit event publishing upon /generate endpoint invocation in controller

This will help improve observability and traceability for code generation requests.